### PR TITLE
ENH: Make reading of DeveloperMode setting more robust

### DIFF
--- a/CompareVolumes.py
+++ b/CompareVolumes.py
@@ -55,8 +55,7 @@ Please refer to <a href=\"$a/Documentation/$b.$c/Modules/CompareVolumes\"> the d
 
 class CompareVolumesWidget:
   def __init__(self, parent = None):
-    settings = qt.QSettings()
-    self.developerMode = settings.value('Developer/DeveloperMode').lower() == 'true'
+    self.developerMode = slicer.util.settingsValue('Developer/DeveloperMode', False, converter=slicer.util.toBool)
     if not parent:
       self.parent = slicer.qMRMLWidget()
       self.parent.setLayout(qt.QVBoxLayout())


### PR DESCRIPTION
Similar to the approach in https://github.com/Slicer/Slicer/commit/fba6424, make
reading the DeveloperMode setting more robust. The setting lookup now handles
when the setting doesn't exist and when it returns a bool, as in Qt5. This fixes
the following error:

    AttributeError: 'bool' object has no attribute 'lower'