### PR TITLE
PERF: Only refresh VolumeOrderSelect for volume node changes

### DIFF
--- a/CompareVolumes.py
+++ b/CompareVolumes.py
@@ -253,9 +253,13 @@ class VolumeOrderSelect:
       for observation in self.observations:
         slicer.mrmlScene.RemoveObserver(observation)
 
-    def refresh(self, caller=None, event=None):
+    @vtk.calldata_type(vtk.VTK_OBJECT)
+    def refresh(self, caller=None, event=None, call_data=None):
       """synchronize list items with current volume
       nodes in scene while retaining order and check state"""
+      if call_data is not None:
+        if not call_data.IsA("vtkMRMLVolumeNode"):
+          return
       listModel = self.listWidget.model()
       # first, save the order and checkstate
       previousVolumeIDs = []


### PR DESCRIPTION
This PR makes a small change to avoid executing the logic in `VolumeOrderSelect.refresh` unnecessarily (i.e., when a node is added to or removed from the scene that is not a type of volume node. In our slicer-based application, we noticed a degradation in performance when we had a lot of volume nodes in the scene and were adding non-volume nodes. 

This is a bit of a band-aid fix and it may be better in the long run to switch `VolumeOrderSelect.listWidget` to something like a `qMRMLSubjectHiearchyTreeView`. I took a look at dropping in the `qMRMLListWidget`, but it does not appear to have an implementation for synchronizing with the mrml scene / filtering out nodes by type like the `qMRMLNodeComboBox` for example.

In any case, the current PR should maintain the current functionality of the module and provide a modest performance improvement in some use cases.