### PR TITLE
ENH: Replace deprecated AddActor2D usage

### DIFF
--- a/CompareVolumes.py
+++ b/CompareVolumes.py
@@ -791,7 +791,7 @@ class LayerReveal(ViewWatcher):
       self.cursorOn()
       self.sliceView.forceRender()
     elif event == "EnterEvent":
-      self.renderer.AddActor2D(self.actor2D)
+      self.renderer.AddViewProp(self.actor2D)
       if self.layerVolumeNodes['F'] and (self.layerVolumeNodes['F'] != self.layerVolumeNodes['B']):
         self.cursorOff(self.sliceWidget)
     else:


### PR DESCRIPTION
As of VTK 9.5.0 (per https://github.com/Kitware/VTK/commit/8ec4ae2050c555d1894e2a90029316be4e1ffbea), AddActor2D is deprecated and AddViewProp should be used instead.

This was found while working on adding VTK 9.7 support to Slicer (https://github.com/Slicer/Slicer/pull/9264) where CompareVolumes is a remote extension built into Slicer. `AddActor2D` deprecation has expired and is no longer present in VTK 9.7.

cc: @pieper @lassoan for integration help